### PR TITLE
Fix writing multiple headers with the same key

### DIFF
--- a/lib/http/protocol/http11/connection.rb
+++ b/lib/http/protocol/http11/connection.rb
@@ -95,7 +95,9 @@ module HTTP
 				
 				def write_headers(headers)
 					headers.each do |name, value|
-						@stream.write("#{name}: #{value}\r\n")
+						value.to_s.split("\n").each do |val|
+							@stream.write("#{name}: #{val}\r\n")
+						end
 					end
 				end
 				


### PR DESCRIPTION
This is a rather crude patch, but it highlights the issue behind https://github.com/socketry/falcon/issues/19